### PR TITLE
Introducing Abacus.store APIs as a CRUD abstraction on top of localStorage

### DIFF
--- a/build.json
+++ b/build.json
@@ -5,7 +5,8 @@
 				"src/abacus.js",
 				"src/abacus.timer.js",
 				"src/abacus.tween.js",
-				"src/abacus.animation.js"
+				"src/abacus.animation.js",
+				"src/abacus.store.js"
 			],
 			"prehint": true,
 			"posthint": true,

--- a/index.html
+++ b/index.html
@@ -3,8 +3,12 @@
 <html>
 <head>
   <meta>
-  <title>Boilerplate demo</title>
-  <script src="src/boilerplate.js"></script>
+  <title>Abaucs</title>
+  <script src="src/abacus.js"></script>
+  <script src="src/abacus.animation.js"></script>
+  <script src="src/abacus.timer.js"></script>
+  <script src="src/abacus.tween.js"></script>
+  <script src="src/abacus.store.js"></script>
 </head>
 <body>
 

--- a/src/abacus.entity.js
+++ b/src/abacus.entity.js
@@ -97,5 +97,7 @@
   Abacus.entity.flush = function() {
     entities = [];
   };
+  
+  Abacus.entity.entities = entities;
 
 })( this, this.Abacus );

--- a/src/abacus.store.js
+++ b/src/abacus.store.js
@@ -9,21 +9,21 @@
   // TODO: introduce strategy for different Abacus entities to persist
   // at different endpoints
   Abacus.store = {
-    create: function( id, value ){
+    create: function( id, value ) {
       abacusCache[ id ] = value;
       window.localStorage.setItem( 'Abacus', JSON.stringify( abacusCache ) );
       return this;
     },
-    read: function( id ){
+    read: function( id ) {
       var abacusCache = JSON.parse( window.localStorage.getItem( 'Abacus') );
       return abacusCache[ id ];
     },
-    update: function( id, value ){
+    update: function( id, value ) {
       Abacus.extend( abacusCache[ id ], value );
       window.localStorage.setItem( 'Abacus', JSON.stringify( abacusCache ) );
       return this;
     },
-    destroy: function( id ){
+    destroy: function( id ) {
       delete abacusCache[ id ];
       window.localStorage.setItem( 'Abacus', JSON.stringify( abacusCache ) );
       return this;

--- a/src/abacus.store.js
+++ b/src/abacus.store.js
@@ -1,5 +1,5 @@
 (function( window, Abacus ) {
-  
+
   // Local cache for Abacus
   var abacusCache = {};
 

--- a/src/abacus.store.js
+++ b/src/abacus.store.js
@@ -1,12 +1,9 @@
 (function( window, Abacus ) {
   
-  var abacusCache = {};
-
   // Local cache for Abacus
   var abacusCache = {};
 
-  // Abacus store API for storing arbitrary objects
-  // Store defaults to using localStorage
+  // Abacus store API for storing arbitrary objects in localStorage
   // Overwrite these methods to introduce your own persistance layer
   // TODO: introduce strategy for different Abacus entities to persist
   // at different endpoints

--- a/src/abacus.store.js
+++ b/src/abacus.store.js
@@ -3,7 +3,8 @@
   // Local cache for Abacus
   var abacusCache = {};
 
-  // Abacus store API for storing arbitrary objects in localStorage
+  // Abacus store API for storing arbitrary objects
+  // Store defaults to using localStorage
   // Overwrite these methods to introduce your own persistance layer
   // TODO: introduce strategy for different Abacus entities to persist
   // at different endpoints

--- a/src/abacus.store.js
+++ b/src/abacus.store.js
@@ -1,17 +1,29 @@
 (function( window, Abacus ) {
+  
+  var abacusCache = {};
 
   Abacus.store = {
-    get: function( id ){
-      
+    create: function( id, value ){
+      abacusCache[ id ] = value;
+      window.localStorage.setItem( 'Abacus', JSON.stringify( abacusCache ) );
+      return this;
     },
-    set: function( id ){
-      
+    read: function( id ){
+      var abacusCache = JSON.parse( window.localStorage.getItem( 'Abacus') );      
+      return abacusCache[ id ];
+    },
+    update: function( id, value ){
+      Abacus.extend( abacusCache[ id ], value );
+      window.localStorage.setItem( 'Abacus', JSON.stringify( abacusCache ) );      
+      return this;
     },
     destroy: function( id ){
-      
+      delete abacusCache[ id ];
+      window.localStorage.setItem( 'Abacus', JSON.stringify( abacusCache ) );
+      return this;
     },
-    update: function( id ){
-      
+    readAll: function() {
+      return JSON.parse( window.localStorage.getItem( 'Abacus') );      
     }
   };
 

--- a/src/abacus.store.js
+++ b/src/abacus.store.js
@@ -15,12 +15,12 @@
       return this;
     },
     read: function( id ){
-      var abacusCache = JSON.parse( window.localStorage.getItem( 'Abacus') );      
+      var abacusCache = JSON.parse( window.localStorage.getItem( 'Abacus') );
       return abacusCache[ id ];
     },
     update: function( id, value ){
       Abacus.extend( abacusCache[ id ], value );
-      window.localStorage.setItem( 'Abacus', JSON.stringify( abacusCache ) );      
+      window.localStorage.setItem( 'Abacus', JSON.stringify( abacusCache ) );
       return this;
     },
     destroy: function( id ){
@@ -29,7 +29,7 @@
       return this;
     },
     readAll: function() {
-      return JSON.parse( window.localStorage.getItem( 'Abacus') );      
+      return JSON.parse( window.localStorage.getItem( 'Abacus') );
     }
   };
 })( this, this.Abacus );

--- a/src/abacus.store.js
+++ b/src/abacus.store.js
@@ -1,7 +1,12 @@
 (function( window, Abacus ) {
   
+  // Local cache for Abacus
   var abacusCache = {};
 
+  // Abacus store API for storing arbitrary objects in localStorage
+  // Overwrite these methods to introduce your own persistance layer
+  // TODO: introduce strategy for different Abacus entities to persist
+  // at different endpoints
   Abacus.store = {
     create: function( id, value ){
       abacusCache[ id ] = value;
@@ -26,5 +31,4 @@
       return JSON.parse( window.localStorage.getItem( 'Abacus') );      
     }
   };
-
 })( this, this.Abacus );

--- a/src/abacus.store.js
+++ b/src/abacus.store.js
@@ -1,0 +1,5 @@
+(function( window, Abacus ) {
+
+  Abacus.store = {};
+
+})( this, this.Abacus );

--- a/src/abacus.store.js
+++ b/src/abacus.store.js
@@ -1,35 +1,38 @@
 (function( window, Abacus ) {
-  
-  // Local cache for Abacus
-  var abacusCache = {};
 
   // Abacus store API for storing arbitrary objects
   // Store defaults to using localStorage
   // Overwrite these methods to introduce your own persistance layer
   // TODO: introduce strategy for different Abacus entities to persist
   // at different endpoints
-  Abacus.store = {
-    create: function( id, value ) {
-      abacusCache[ id ] = value;
-      window.localStorage.setItem( 'Abacus', JSON.stringify( abacusCache ) );
-      return this;
-    },
-    read: function( id ) {
-      var abacusCache = JSON.parse( window.localStorage.getItem( 'Abacus') );
-      return abacusCache[ id ];
-    },
-    update: function( id, value ) {
-      Abacus.extend( abacusCache[ id ], value );
-      window.localStorage.setItem( 'Abacus', JSON.stringify( abacusCache ) );
-      return this;
-    },
-    destroy: function( id ) {
-      delete abacusCache[ id ];
-      window.localStorage.setItem( 'Abacus', JSON.stringify( abacusCache ) );
-      return this;
-    },
-    readAll: function() {
-      return JSON.parse( window.localStorage.getItem( 'Abacus') );
+  Abacus.store = function( id, value) {
+    this._id = 'Abacus';
+    this._cache = JSON.parse( window.localStorage.getItem( ( this.get ? this.get('id') : this._id ) ) ) || {};
+    
+    console.log( this._cache )
+    
+    // If there is an id and a value
+    // then we are setting
+    if ( id && value ) {
+      this._cache[ id ] = value;
+
+    // If there is just an id then we are getting
+    } else if ( id ){      
+      return this._cache[ id ];
+
+    // Otherwise, we are reading all props
+    } else {
+      return JSON.parse( window.localStorage.getItem( ( this.get ? this.get('id') : this._id ) ) );
+
     }
+
+    window.localStorage.setItem( ( this.get ? this.get('id') : this._id ), JSON.stringify( this._cache ) );
+    return this;
   };
+  
+  // Define a destroy method
+  Abacus.store.destroy = function( id ) {
+    delete this._cache[ id ];
+  };
+
 })( this, this.Abacus );

--- a/src/abacus.store.js
+++ b/src/abacus.store.js
@@ -1,5 +1,18 @@
 (function( window, Abacus ) {
 
-  Abacus.store = {};
+  Abacus.store = {
+    get: function( id ){
+      
+    },
+    set: function( id ){
+      
+    },
+    destroy: function( id ){
+      
+    },
+    update: function( id ){
+      
+    }
+  };
 
 })( this, this.Abacus );

--- a/src/abacus.store.js
+++ b/src/abacus.store.js
@@ -1,4 +1,6 @@
 (function( window, Abacus ) {
+  
+  var abacusCache = {};
 
   // Local cache for Abacus
   var abacusCache = {};

--- a/test/index.html
+++ b/test/index.html
@@ -12,11 +12,13 @@
   <script src="../src/abacus.tween.js"></script>
   <script src="../src/abacus.timer.js"></script>
   <script src="../src/abacus.animation.js"></script>
+  <script src="../src/abacus.store.js"></script>
   <!-- tests -->
   <script src="unit/abacus.js"></script>
   <script src="unit/abacus.tween.js"></script>
   <script src="unit/abacus.timer.js"></script>
   <script src="unit/abacus.animation.js"></script>
+  <script src="unit/abacus.store.js"></script>
 </head>
 <body>
  <h1 id="qunit-header">Abacus Unit Tests</h1>

--- a/test/unit/abacus.store.js
+++ b/test/unit/abacus.store.js
@@ -1,0 +1,4 @@
+module('Store');
+test('Test that the Abacus.store exists', 1, function() {
+  ok( Abacus.store, 'Abacus.store exists' );
+});

--- a/test/unit/abacus.store.js
+++ b/test/unit/abacus.store.js
@@ -1,4 +1,19 @@
 module('Store');
-test('Test that the Abacus.store exists', 1, function() {
+test('Test that the Abacus.store and its methods exists', 6, function() {
   ok( Abacus.store, 'Abacus.store exists' );
+  ok( Abacus.store.create, 'Abacus.store.create exists' );
+  ok( Abacus.store.read, 'Abacus.store.read exists' );
+  ok( Abacus.store.update, 'Abacus.store.update exists' );
+  ok( Abacus.store.destroy, 'Abacus.store.destroy exists' );
+  ok( Abacus.store.readAll, 'Abacus.store.readAll exists' );
+});
+
+test('Test the Abacus.store methods', 4, function() {
+
+Abacus.store.create( 'asd', {name: 'boaz'} )
+
+  equal( Abacus.store.read( 'asd' ).name, 'boaz', 'Abacus.store.read returns a property from the target object correctly' );
+  equal( Abacus.store.update( 'asd', { age: 25 } ).read('asd').age, 25, 'Abacus.store.update adds a property to the target object correctly' );
+  equal( Abacus.store.destroy( 'asd' ).read( 'asd' ), undefined , 'Abacus.store.destroy removes the target object from the cache' );
+  equal( typeof Abacus.store.readAll(), 'object', 'Abacus.store.readAll returns an object' );
 });

--- a/test/unit/abacus.store.js
+++ b/test/unit/abacus.store.js
@@ -1,19 +1,27 @@
 module('Store');
 test('Test that the Abacus.store and its methods exists', 6, function() {
   ok( Abacus.store, 'Abacus.store exists' );
-  ok( Abacus.store.create, 'Abacus.store.create exists' );
+  ok( Abacus.store.storageId, 'Abacus.store.storageId exists' );
+  ok( Abacus.store._cache, 'Abacus.store._cache exists' );
   ok( Abacus.store.read, 'Abacus.store.read exists' );
-  ok( Abacus.store.update, 'Abacus.store.update exists' );
+  ok( Abacus.store.save, 'Abacus.store.save exists' );
   ok( Abacus.store.destroy, 'Abacus.store.destroy exists' );
-  ok( Abacus.store.readAll, 'Abacus.store.readAll exists' );
 });
 
 test('Test the Abacus.store methods', 4, function() {
+  
+  // Clear out local storage to make sure 
+  // we get consistant results
+  Abacus.store.destroy()
 
-Abacus.store.create( 'asd', {name: 'boaz'} )
+  boaz = Abacus.entity({ name: 'boaz', age: 25 });
+  pete = Abacus.entity({ name: 'pete', age: 28 });
+  irene = Abacus.entity({ name: 'irene', age: 26 });
+  
+  Abacus.extend( boaz, Abacus.store );
+  Abacus.extend( pete, Abacus.store );
+  Abacus.extend( irene, Abacus.store );
 
-  equal( Abacus.store.read( 'asd' ).name, 'boaz', 'Abacus.store.read returns a property from the target object correctly' );
-  equal( Abacus.store.update( 'asd', { age: 25 } ).read('asd').age, 25, 'Abacus.store.update adds a property to the target object correctly' );
-  equal( Abacus.store.destroy( 'asd' ).read( 'asd' ), undefined , 'Abacus.store.destroy removes the target object from the cache' );
-  equal( typeof Abacus.store.readAll(), 'object', 'Abacus.store.readAll returns an object' );
+  equal( typeof Abacus.store.read(), 'object', 'Abacus.store.read returns an object' );
+
 });


### PR DESCRIPTION
This is a stub for us to start using to persist `Abacus.entity` entities and other Abacus data locally until we come up with a persistance model/strategy for Abacus modules to persist themselves independently.
